### PR TITLE
Use bash explicitly

### DIFF
--- a/lib/docsplit/image_extractor.rb
+++ b/lib/docsplit/image_extractor.rb
@@ -41,13 +41,14 @@ module Docsplit
         # We're adding `| grep -v '^$' | uniq` here and below because if a corrupt PDF is parsed, it generates an infinite amount of identical warnings (with blank lines in between).
         # By filtering these we avoid memory bloat when the executing process tries to capture stdout.
         # See https://github.com/GetSilverfin/silverfin/issues/1998
-        result = `MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 timeout #{timeout} gm mogrify #{common} -unsharp 0x0.5+0.75 \"#{directory}/*.#{format}\" 2>&1 | grep -v '^$' | uniq; exit ${PIPESTATUS[0]}`.chomp
+        cmd = "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 timeout #{timeout} gm mogrify #{common} -unsharp 0x0.5+0.75 \"#{directory}/*.#{format}\" 2>&1 | grep -v \"^$\" | uniq; exit ${PIPESTATUS[0]}"
+        result = `bash -c '#{cmd}'`.chomp
         raise ExtractionFailed, result if $? != 0
       else
         page_list(pages).each do |page|
           out_file  = ESCAPE[File.join(directory, "#{basename}_#{page}.#{format}")]
-          cmd = "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 timeout #{timeout} gm convert +adjoin -define pdf:use-cropbox=true #{common} #{escaped_pdf}[#{page - 1}] #{out_file} 2>&1 | grep -v '^$' | uniq; exit ${PIPESTATUS[0]}".chomp
-          result = `#{cmd}`.chomp
+          cmd = "MAGICK_TMPDIR=#{tempdir} OMP_NUM_THREADS=2 timeout #{timeout} gm convert +adjoin -define pdf:use-cropbox=true #{common} #{escaped_pdf}[#{page - 1}] #{out_file} 2>&1 | grep -v \"^$\" | uniq; exit ${PIPESTATUS[0]}"
+          result = `bash -c '#{cmd}'`.chomp
           raise ExtractionFailed, result if $? != 0
         end
       end


### PR DESCRIPTION
This calls bash from within /bin/sh subshell to ensure PIPESTATUS variable works (in some environments the subshell does not have it by default).