### PR TITLE
Adding timeout to pdf extraction calls.

### DIFF
--- a/lib/docsplit/external_process.rb
+++ b/lib/docsplit/external_process.rb
@@ -1,9 +1,7 @@
 module Docsplit
   module ExternalProcess
-    COMMAND_TIMEOUT = 300 # seconds
-
     # Run an external process and raise an exception if it fails.
-    def run(command, env = "")
+    def run(command, env = "", timeout = nil)
       # If a corrupt PDF is parsed, it generates an infinite amount of identical warnings (with blank lines in between).
       # By filtering these we avoid memory bloat when the executing process tries to capture stdout. The timeout makes
       # sure we exit at some point.
@@ -12,23 +10,26 @@ module Docsplit
       # - Add timeout so a stuck process doesn't block our Ruby process forever
       # - Remove blank lines
       # - Remove duplicate lines
-      run_command = "#{env} #{timeout} #{command} | grep -v \"^$\" | uniq"
+      run_command = "#{env} #{timeout_prefix(timeout)} #{command} | grep -v \"^$\" | uniq"
 
       # - Run through bash so we can use PIPESTATUS
       # - Use PIPESTATUS to return the exit status of #{command} instead of `uniq`
       result = `bash -c '#{run_command}; exit ${PIPESTATUS[0]}'`.chomp
+      exit_code = $? >> 8
 
-      raise ExtractionFailed, result if $? != 0
+      raise TimeoutError, run_command if exit_code == 137
+      raise ExtractionFailed, result if exit_code != 0
+
       result
     end
 
-    def timeout
-      "#{timeout_bin} #{COMMAND_TIMEOUT}"
+    def timeout_prefix(timeout)
+      timeout ? "#{timeout_bin} #{timeout}" : ""
     end
 
     def timeout_bin
       # gtimeout on Mac
-      `which timeout` != "" ? "timeout" : "gtimeout"
+      `which timeout` != "" ? "timeout --signal=KILL" : "gtimeout --signal=KILL"
     end
   end
 end

--- a/lib/docsplit/pdf_extractor.rb
+++ b/lib/docsplit/pdf_extractor.rb
@@ -2,8 +2,14 @@ require 'rbconfig'
 
 module Docsplit
   class PdfExtractor
+    include ExternalProcess
+
     @@executable     = nil
     @@version_string = nil
+
+    def initialize(timeout = nil)
+      @timeout = timeout
+    end
 
     # Provide a set of helper functions to determine the OS.
     HOST_OS = (defined?("RbConfig") ? RbConfig : Config)::CONFIG['host_os']
@@ -16,7 +22,7 @@ module Docsplit
     def linux?
       !!HOST_OS.match(/linux/i)
     end
-    
+
     # The first line of the help output holds the name and version number
     # of the office software to be used for extraction.
     def version_string
@@ -35,10 +41,10 @@ module Docsplit
     def open_office?
       !!version_string.match(/^OpenOffice.org/)
     end
-    
+
     # A set of default locations to search for office software
     # These have been extracted from JODConverter.  Each listed
-    # path should contain a directory "program" which in turn 
+    # path should contain a directory "program" which in turn
     # contains the "soffice" executable.
     # see: https://github.com/mirkonasato/jodconverter/blob/master/jodconverter-core/src/main/java/org/artofsolving/jodconverter/office/OfficeUtils.java#L63-L91
     def office_search_paths
@@ -69,7 +75,7 @@ module Docsplit
       end
       search_paths
     end
-    
+
     # Identify the path to a working office executable.
     def office_executable
       paths = office_search_paths
@@ -81,7 +87,7 @@ module Docsplit
         raise ArgumentError, "No such file or directory #{ENV['OFFICE_PATH']}" unless File.exists? ENV['OFFICE_PATH']
         paths.unshift(ENV['OFFICE_PATH'])
       end
-      
+
       # The location of the office executable is OS dependent
       path_pieces = ["soffice"]
       if windows?
@@ -91,7 +97,7 @@ module Docsplit
       else
         path_pieces += [["program", "soffice"]]
       end
-      
+
       # Search for the first suitable office executable
       # and short circuit an executable is found.
       paths.each do |path|
@@ -107,38 +113,40 @@ module Docsplit
       raise OfficeNotFound, "No office software found" unless @@executable
       @@executable
     end
-    
+
     # Used to specify the office location for JODConverter
     def office_path
       File.dirname(File.dirname(office_executable))
     end
-    
+
     # Convert documents to PDF.
     def extract(docs, opts)
-      out = opts[:output] || '.'
-      FileUtils.mkdir_p out unless File.exists?(out)
-      [docs].flatten.each do |doc|
-        ext = File.extname(doc)
-        basename = File.basename(doc, ext)
-        escaped_doc, escaped_out, escaped_basename = [doc, out, basename].map(&ESCAPE)
+      Timeout.timeout(@timeout, Docsplit::TimeoutError) do
+        out = opts[:output] || '.'
+        FileUtils.mkdir_p out unless File.exists?(out)
+        [docs].flatten.each do |doc|
+          ext = File.extname(doc)
+          basename = File.basename(doc, ext)
+          escaped_doc, escaped_out, escaped_basename = [doc, out, basename].map(&ESCAPE)
 
-        if GM_FORMATS.include?(`file -b --mime #{ESCAPE[doc]}`.strip.split(/[:;]\s+/)[0])
-          `gm convert #{escaped_doc} #{escaped_out}/#{escaped_basename}.pdf`
-        else
-          if libre_office?
-            # Set the LibreOffice user profile, so that parallel uses of cloudcrowd don't trip over each other.
-            Dir.mktmpdir do |tmp_sys_dir|
-              ENV['SYSUSERCONFIG']="file://#{tmp_sys_dir}"
+          if GM_FORMATS.include?(`file -b --mime #{ESCAPE[doc]}`.strip.split(/[:;]\s+/)[0])
+            `gm convert #{escaped_doc} #{escaped_out}/#{escaped_basename}.pdf`
+          else
+            if libre_office?
+              # Set the LibreOffice user profile, so that parallel uses of cloudcrowd don't trip over each other.
+              Dir.mktmpdir do |tmp_sys_dir|
+                ENV['SYSUSERCONFIG']="file://#{tmp_sys_dir}"
 
-              options = "--headless --invisible  --norestore --nolockcheck --convert-to pdf --outdir #{escaped_out} #{escaped_doc}"
-              cmd = "#{office_executable} #{options} 2>&1"
-              result = `#{cmd}`.chomp
-              raise ExtractionFailed, result if $? != 0
+                options = "--headless --invisible  --norestore --nolockcheck --convert-to pdf --outdir #{escaped_out} #{escaped_doc}"
+                cmd = "#{office_executable} #{options} 2>&1"
+                result = run(cmd, "", @timeout)
+                raise ExtractionFailed, result if $? != 0
+              end
+              true
+            else # open office presumably, rely on JODConverter to figure it out.
+              options = "-jar #{ESCAPED_ROOT}/vendor/jodconverter/jodconverter-core-3.0-beta-4.jar -r #{ESCAPED_ROOT}/vendor/conf/document-formats.js"
+              run_jod "#{options} #{escaped_doc} #{escaped_out}/#{escaped_basename}.pdf", [], {}
             end
-            true
-          else # open office presumably, rely on JODConverter to figure it out.
-            options = "-jar #{ESCAPED_ROOT}/vendor/jodconverter/jodconverter-core-3.0-beta-4.jar -r #{ESCAPED_ROOT}/vendor/conf/document-formats.js"
-            run_jod "#{options} #{escaped_doc} #{escaped_out}/#{escaped_basename}.pdf", [], {}
           end
         end
       end
@@ -149,16 +157,16 @@ module Docsplit
     LOGGING       = "-Djava.util.logging.config.file=#{ESCAPED_ROOT}/vendor/logging.properties"
 
     HEADLESS      = "-Djava.awt.headless=true"
-    
+
     private
-    
+
     # Runs a Java command, with quieted logging, and the classpath set properly.
     def run_jod(command, pdfs, opts, return_output=false)
 
       pdfs   = [pdfs].flatten.map{|pdf| "\"#{pdf}\""}.join(' ')
       office = osx? ? "-Doffice.home=#{office_path}" : office_path
       cmd    = "java #{HEADLESS} #{LOGGING} #{office} -cp #{CLASSPATH} #{command} #{pdfs} 2>&1"
-      result = `#{cmd}`.chomp
+      result = run(cmd, "", @timeout)
       raise ExtractionFailed, result if $? != 0
       return return_output ? (result.empty? ? nil : result) : true
     end


### PR DESCRIPTION
Added timeout variants of pdf, image and text extraction methods. New methods are added instead of expanding existing ones to keep backward compatibility.

On top of timeouts for each method, text and image extraction are also equiped with timeouts for single page processing (item_timeout) that can be set indipendently.

All timeout values are now also forwarded to run method in ExternalProcess which is using it for controlling shell process executions. Also, we are now timeouting with SIGKILL since sending SIGTERM can leave orphan processes still running.

All shell calls in changed methods are now converted from back ticks to run call. 