### PR TITLE
Use PDF info to exctract information about encrypted files

### DIFF
--- a/lib/docsplit.rb
+++ b/lib/docsplit.rb
@@ -12,7 +12,7 @@ module Docsplit
   ROOT          = File.expand_path(File.dirname(__FILE__) + '/..')
   ESCAPED_ROOT  = ESCAPE[ROOT]
 
-  METADATA_KEYS = [:author, :date, :creator, :keywords, :producer, :subject, :title, :length]
+  METADATA_KEYS = [:author, :date, :creator, :keywords, :producer, :subject, :title, :length, :encrypted]
 
   GM_FORMATS    = ["image/gif", "image/jpeg", "image/png", "image/x-ms-bmp", "image/svg+xml", "image/tiff", "image/x-portable-bitmap", "application/postscript", "image/x-portable-pixmap"]
 
@@ -102,6 +102,18 @@ module Docsplit
   # Utility method to clean OCR'd text with garbage characters.
   def self.clean_text(text)
     TextCleaner.new.clean(text)
+  end
+
+  def self.extract_permissions(pdfs, opts={})
+    pdfs = ensure_pdfs(pdfs)
+    permissions = InfoExtractor.new.extract(:permissions, pdfs, opts)
+
+    return {"print"=>true, "copy"=>true, "change"=>true, "addNotes"=>true} if permissions.nil?
+
+    permissions.split(" ").map do |permission_pair|
+      key, value = permission_pair.split(":")
+      [key, value == 'yes']
+    end.to_h
   end
 
   private

--- a/lib/docsplit/command_line.rb
+++ b/lib/docsplit/command_line.rb
@@ -15,7 +15,7 @@ Usage:
   Main commands:
     pages, images, text, pdf.
   Metadata commands:
-    author, date, creator, keywords, producer, subject, title, length.
+    author, date, creator, keywords, producer, subject, title, length, encrypted, permissions.
 
 Example:
   docsplit images --size 700x --format jpg document.pdf

--- a/lib/docsplit/info_extractor.rb
+++ b/lib/docsplit/info_extractor.rb
@@ -5,14 +5,16 @@ module Docsplit
 
     # Regex matchers for different bits of information.
     MATCHERS = {
-      :author   => /^Author:\s+([^\n]+)/,
-      :date     => /^CreationDate:\s+([^\n]+)/,
-      :creator  => /^Creator:\s+([^\n]+)/,
-      :keywords => /^Keywords:\s+([^\n]+)/,
-      :producer => /^Producer:\s+([^\n]+)/,
-      :subject  => /^Subject:\s+([^\n]+)/,
-      :title    => /^Title:\s+([^\n]+)/,
-      :length   => /^Pages:\s+([^\n]+)/,
+      :author      => /^Author:\s+([^\n]+)/,
+      :date        => /^CreationDate:\s+([^\n]+)/,
+      :creator     => /^Creator:\s+([^\n]+)/,
+      :keywords    => /^Keywords:\s+([^\n]+)/,
+      :producer    => /^Producer:\s+([^\n]+)/,
+      :subject     => /^Subject:\s+([^\n]+)/,
+      :title       => /^Title:\s+([^\n]+)/,
+      :length      => /^Pages:\s+([^\n]+)/,
+      :encrypted   => /^Encrypted:\s+([^\n]+)/,
+      :permissions => /^Permissions:\s+([^\n]+)/,
     }
 
     # Pull out a single datum from a pdf.

--- a/test/unit/test_extract_info.rb
+++ b/test/unit/test_extract_info.rb
@@ -23,6 +23,20 @@ class ExtractInfoTest < Minitest::Test
     assert 2 == Docsplit.extract_length('test/fixtures/obama_arts.pdf')
   end
 
+  def test_encrypted
+    assert "RC4 128-bit" == Docsplit.extract_encrypted('test/fixtures/encrypted.pdf')
+  end
+
+  def test_permissions
+    expected_permissions_hash = {"print"=>false, "copy"=>false, "change"=>true, "addNotes"=>true}
+    assert_equal expected_permissions_hash, Docsplit.extract_permissions('test/fixtures/encrypted.pdf')
+  end
+
+  def test_permissions_on_non_encrypted_file
+    expected_permissions_hash = {"print"=>true, "copy"=>true, "change"=>true, "addNotes"=>true}
+    assert_equal expected_permissions_hash, Docsplit.extract_permissions('test/fixtures/obama_veterans.doc')
+  end
+
   def test_producer
     assert "Mac OS X 10.6.2 Quartz PDFContext" == Docsplit.extract_producer('test/fixtures/encrypted.pdf')
   end
@@ -49,7 +63,8 @@ class ExtractInfoTest < Minitest::Test
     assert metadata[:producer] == "Acrobat Distiller 8.1.0 (Windows)"
     assert metadata[:title] == "Microsoft Word - Fact Sheet Arts 112907 FINAL.doc"
     assert metadata[:length] == 2
-    assert metadata.length == 6
+    assert metadata[:encrypted] == 'no'
+    assert metadata.length == 7
   end
 
 end


### PR DESCRIPTION
Extends the usage of `pdfinfo` to extract information about `encryption` and `permissions` of the file.

While file is completely encrypted this information still can not be gathered, but if file is only encrypted for copying or printing, this information would be properly extracted.