### PR TITLE
Cover different pdfinfo output

### DIFF
--- a/test/unit/test_extract_info.rb
+++ b/test/unit/test_extract_info.rb
@@ -24,7 +24,8 @@ class ExtractInfoTest < Minitest::Test
   end
 
   def test_encrypted
-    assert "RC4 128-bit" == Docsplit.extract_encrypted('test/fixtures/encrypted.pdf')
+    assert_equal true, Docsplit.extract_encrypted('test/fixtures/encrypted.pdf')
+    assert_equal false, Docsplit.extract_encrypted('test/fixtures/obama_arts.pdf')
   end
 
   def test_permissions


### PR DESCRIPTION
Depending on the underlying library `pdfinfo` returns results in slightly different format so the encryption and permissions details can be placed inside a single `encrypted` field.

This PR adds support for outputs like:

```
Creator:        Adobe Acrobat 22.3
Producer:       Adobe Acrobat 22.3 Image Conversion Plug-in
CreationDate:   Wed Nov 30 13:15:07 2022 UTC
ModDate:        Thu Dec  1 09:33:04 2022 UTC
Tagged:         no
UserProperties: no
Suspects:       no
Form:           none
JavaScript:     no
Pages:          1
Encrypted:      yes (print:yes copy:no change:no addNotes:yes algorithm:AES-256)
Page size:      3024 x 4032 pts
Page rot:       0
File size:      1916712 bytes
Optimized:      yes
PDF version:    1.7
```

and 

```
Title:          IMG_4613 (1).HEIC
Creator:        Preview
Producer:       macOS Version 12.5.1 (Build 21G83) Quartz PDFContext
CreationDate:   Mon Oct 17 08:04:34 2022 UTC
ModDate:        Mon Oct 17 08:04:34 2022 UTC
Tagged:         no
UserProperties: no
Suspects:       no
Form:           none
JavaScript:     no
Pages:          1
Encrypted:      no
Page size:      595 x 842 pts (A4)
Page rot:       0
File size:      15863348 bytes
Optimized:      no
PDF version:    1.3
```