### PR TITLE
Replace Process::Status#>> deprecation with Process::Status#exitstatus

### DIFF
--- a/lib/docsplit/external_process.rb
+++ b/lib/docsplit/external_process.rb
@@ -15,7 +15,7 @@ module Docsplit
       # - Run through bash so we can use PIPESTATUS
       # - Use PIPESTATUS to return the exit status of #{command} instead of `uniq`
       result = `bash -c '#{run_command}; exit ${PIPESTATUS[0]}'`.chomp
-      exit_code = $? >> 8
+      exit_code = $?.exitstatus
 
       raise TimeoutError, run_command if exit_code == 137
       raise ExtractionFailed, result if exit_code != 0


### PR DESCRIPTION
`Process::Status`' `>>` is deprecated and will be removed in Ruby 3.4:

```ruby
[5]dev:silverfin(main):0> $? >> 8
(irb):5: warning: Process::Status#>> is deprecated and will be removed in Ruby 3.4; use Process::Status#exitstatus or Process::Status#stopsig instead
=> 0
```